### PR TITLE
Return result of transaction operation

### DIFF
--- a/lib/src/postgresql_impl/connection.dart
+++ b/lib/src/postgresql_impl/connection.dart
@@ -496,8 +496,9 @@ class ConnectionImpl implements Connection {
 
     try {
       await execute(begin);
-      await operation();
+      final result = await operation();
       await execute('commit');
+      return result;
     } catch (_) {
       await execute('rollback');
       rethrow;


### PR DESCRIPTION
It would be better if Connection.runInTransaction returns the result of the operation after successfull commiting.