### PR TITLE
Support of list types in DefaultTypeConverter

### DIFF
--- a/lib/src/postgresql_impl/type_converter.dart
+++ b/lib/src/postgresql_impl/type_converter.dart
@@ -142,7 +142,7 @@ class DefaultTypeConverter implements TypeConverter {
       return encodeString(json.encode(value));
   
     if (value is List)
-      return encodeArray(value);
+      return encodeArray(value, getConnectionName);
   
     throw _error('Unsupported runtime type as query parameter '
         '(${value.runtimeType}).', getConnectionName);
@@ -155,10 +155,10 @@ class DefaultTypeConverter implements TypeConverter {
     return n.toString();
   }
   
-  String encodeArray(List value) {
-    //TODO implement postgresql array types
-    throw _error('Postgresql array types not implemented yet. '
-        'Pull requests welcome ;)', null);
+  String encodeArray(List value, getConnectionName()) {
+    return value
+      .map((e) => encodeValueDefault(e, getConnectionName: getConnectionName))
+      .join(', ');
   }
   
   String encodeDateTime(DateTime datetime, {bool isDateOnly}) {


### PR DESCRIPTION
Hi!
For queries like this
```
  Future<List<OrderState>> getStates(final Iterable<int> orderIds) async
  {
    final sql = 'select id, state from orders where id in (@orderIds)';
    final rows = await query(sql, {
      'orderIds': orderIds
    });
    ...
  }
```
it would be nice to have list support for query values. Such query should look like this `select id, state from orders where id in (1, 2, 3)`