### PR TITLE
Parametrized lists,  ±infinity date

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ final result2 = conn.query(
  { "ids": ids });
 ```
 
-It's always better to use `array[@arr]::type[]` syntax in query as it's error prone
+It's always better to use `array[@arr]::type[]` syntax in query as it's error proof
 to empty lists.
 
 ### Closing the connection

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -35,3 +35,9 @@ const
     pePoolStopped = 4002,
     peConnectionClosed = 4003,
     peConnectionFailed = 40004; //miscellaneous connection errors (excluding SQL statement errors)
+
+// pg '-infinity' and 'infinity' representation
+// DateTimes can represent time values that are at a distance of at most 100,000,000
+// days from epoch (1970-01-01 UTC): -271821-04-20 to 275760-09-13.
+DateTime pgMinDateTime = DateTime.utc(-271821,04,20);
+DateTime pgMaxDateTime = DateTime.utc(275760,09,13);

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -36,8 +36,10 @@ const
     peConnectionClosed = 4003,
     peConnectionFailed = 40004; //miscellaneous connection errors (excluding SQL statement errors)
 
-// pg '-infinity' and 'infinity' representation
 // DateTimes can represent time values that are at a distance of at most 100,000,000
 // days from epoch (1970-01-01 UTC): -271821-04-20 to 275760-09-13.
-DateTime pgMinDateTime = DateTime.utc(-271821,04,20);
-DateTime pgMaxDateTime = DateTime.utc(275760,09,13);
+// https://api.dart.dev/stable/2.10.2/dart-core/DateTime-class.html
+/// Dart representation of PostgreSQL '-infinity'
+DateTime dartMinDateTime = DateTime.utc(-271821,04,20);
+/// Dart representation of PostgreSQL 'infinity'
+DateTime dartMaxDateTime = DateTime.utc(275760,09,13);

--- a/lib/src/postgresql_impl/type_converter.dart
+++ b/lib/src/postgresql_impl/type_converter.dart
@@ -152,10 +152,8 @@ class DefaultTypeConverter implements TypeConverter {
     return n.toString();
   }
   
-  String encodeArray(List value) {
-    //TODO implement postgresql array types
-    throw _error('Postgresql array types not implemented yet. '
-        'Pull requests welcome ;)', null);
+  String encodeArray(List values) {
+    return values?.map((value) => encodeValueDefault(value))?.join(', ');
   }
   
   String encodeDateTime(DateTime datetime, {bool isDateOnly}) {

--- a/lib/src/postgresql_impl/type_converter.dart
+++ b/lib/src/postgresql_impl/type_converter.dart
@@ -155,10 +155,8 @@ class DefaultTypeConverter implements TypeConverter {
     return n.toString();
   }
   
-  String encodeArray(List value) {
-    //TODO implement postgresql array types
-    throw _error('Postgresql array types not implemented yet. '
-        'Pull requests welcome ;)', null);
+  String encodeArray(List values) {
+    return values?.map((value) => encodeValueDefault(value))?.join(', ');
   }
   
   String encodeDateTime(DateTime datetime, {bool isDateOnly}) {

--- a/lib/src/postgresql_impl/type_converter.dart
+++ b/lib/src/postgresql_impl/type_converter.dart
@@ -112,10 +112,10 @@ class DefaultTypeConverter implements TypeConverter {
   //    return encodeBytea(value);
   //  }
   //
-  //  if (type == 'array') {
-  //    if (value is! List) throwError();
-  //    return encodeArray(value);
-  //  }
+    if (type == 'array') {
+      if (value is! List) throwError();
+      return encodeArray(value);
+    }
   
     throw _error('Unknown type name: $type.', getConnectionName);
   }
@@ -163,9 +163,9 @@ class DefaultTypeConverter implements TypeConverter {
   
     if (datetime == null)
       return 'null';
-    else if(datetime == pgMinDateTime)
+    else if(datetime == dartMinDateTime)
       return '-infinity';
-    else if(datetime == pgMaxDateTime)
+    else if(datetime == dartMaxDateTime)
       return 'infinity';
 
     var string = datetime.toIso8601String();
@@ -273,9 +273,9 @@ class DefaultTypeConverter implements TypeConverter {
     // capable of creating DateTimes for a non-local time zone.
 
     if (value == '-infinity')
-      return pgMinDateTime;
+      return dartMinDateTime;
     else if(value == 'infinity')
-      return pgMaxDateTime;
+      return dartMaxDateTime;
 
     var formattedValue = value;
 

--- a/lib/src/postgresql_impl/type_converter.dart
+++ b/lib/src/postgresql_impl/type_converter.dart
@@ -163,6 +163,10 @@ class DefaultTypeConverter implements TypeConverter {
   
     if (datetime == null)
       return 'null';
+    else if(datetime == pgMinDateTime)
+      return '-infinity';
+    else if(datetime == pgMaxDateTime)
+      return 'infinity';
 
     var string = datetime.toIso8601String();
 
@@ -268,12 +272,10 @@ class DefaultTypeConverter implements TypeConverter {
     // This restriction could be relaxed by using a more advanced date library
     // capable of creating DateTimes for a non-local time zone.
 
-    if (value == 'infinity' || value == '-infinity') {
-      throw _error('Server returned a timestamp with value '
-          '"$value", this cannot be represented as a dart date object, if '
-          'infinity values are required, rewrite the sql query to cast the '
-          'value to a string, i.e. col::text.', getConnectionName);
-    }
+    if (value == '-infinity')
+      return pgMinDateTime;
+    else if(value == 'infinity')
+      return pgMaxDateTime;
 
     var formattedValue = value;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,10 +3,17 @@ version: 0.5.1+1
 authors:
 - Greg Lowe <greg@vis.net.nz>
 - Tom Yeh <tomyeh@rikulo.org>
+- Martin Edlman <ac@an.y-co.de>
 description: >
   A temporary fork of Greg's PostgreSQL driver (xxgreg/postgresql)
   using conserved substitution respecting strings and @@ operators.
-  also optimizing the pool implementation aggressivly.
+  also optimizing the pool implementation aggressively.
+  With added support for encoding parametrized lists. E.g.
+  List<int> ids = [ ... ]; // init list with values or get it from parameters
+  result1 = db.query("select * from table where id in (@ids)", { "ids": ids });
+  result2 = db.query("select * from table where id = any (array[@ids]::int[])", { "ids": ids });
+  When using array[@x] syntax in query it's wise to use array type cast (::int[], ::date[], ...)
+  to avoid problems with null list.
 homepage: https://github.com/tomyeh/postgresql
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,12 +8,7 @@ description: >
   A temporary fork of Greg's PostgreSQL driver (xxgreg/postgresql)
   using conserved substitution respecting strings and @@ operators.
   also optimizing the pool implementation aggressively.
-  With added support for encoding parametrized lists. E.g.
-  List<int> ids = [ ... ]; // init list with values or get it from parameters
-  result1 = db.query("select * from table where id in (@ids)", { "ids": ids });
-  result2 = db.query("select * from table where id = any (array[@ids]::int[])", { "ids": ids });
-  When using array[@x] syntax in query it's wise to use array type cast (::int[], ::date[], ...)
-  to avoid problems with null list.
+  With added support for encoding parametrized lists. See README.md
 homepage: https://github.com/tomyeh/postgresql
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,10 +3,17 @@ version: 0.5.7
 authors:
 - Greg Lowe <greg@vis.net.nz>
 - Tom Yeh <tomyeh@rikulo.org>
+- Martin Edlman <ac@an.y-co.de>
 description: >
   A temporary fork of Greg's PostgreSQL driver (xxgreg/postgresql)
   using conserved substitution respecting strings and @@ operators.
-  also optimizing the pool implementation aggressivly.
+  also optimizing the pool implementation aggressively.
+  With added support for encoding parametrized lists. E.g.
+  List<int> ids = [ ... ]; // init list with values or get it from parameters
+  result1 = db.query("select * from table where id in (@ids)", { "ids": ids });
+  result2 = db.query("select * from table where id = any (array[@ids]::int[])", { "ids": ids });
+  When using array[@x] syntax in query it's wise to use array type cast (::int[], ::date[], ...)
+  to avoid problems with null list.
 homepage: https://github.com/tomyeh/postgresql
 
 environment:


### PR DESCRIPTION
This PR add support for array of parameters and for ±infinity date. '-infinity' is represented in Dart as minimum possible DateTime `DateTime.utc(-271821,04,20)`, 'infinity' is represented as maximum possible DateTime `DateTime.utc(275760,09,13)`